### PR TITLE
ワークフロー間の git push 競合を解消（rebase + retry） — 同じツイート再投稿問題の根本原因

### DIFF
--- a/.github/workflows/auto-like.yml
+++ b/.github/workflows/auto-like.yml
@@ -50,4 +50,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A history/
-          git diff --cached --quiet || (git commit -m "update like history $(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')" && git push)
+          if git diff --cached --quiet; then
+            echo "変更なし"
+          else
+            git commit -m "update like history $(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')"
+            for i in 1 2 3 4 5; do
+              if git push; then
+                exit 0
+              fi
+              echo "push rejected (attempt $i/5). rebasing and retrying..."
+              sleep $((i * 2))
+              git pull --rebase origin main
+            done
+            echo "push failed after 5 retries"
+            exit 1
+          fi

--- a/.github/workflows/generate-tweets.yml
+++ b/.github/workflows/generate-tweets.yml
@@ -45,8 +45,21 @@ jobs:
           if [ -d history ] && [ -n "$(git status history --porcelain)" ]; then
             git add history/
           fi
-          git commit -m "generate tweets $(TZ=Asia/Tokyo date '+%Y-%m-%d')" || echo "変更なし"
-          git push
+          if git diff --cached --quiet; then
+            echo "変更なし"
+          else
+            git commit -m "generate tweets $(TZ=Asia/Tokyo date '+%Y-%m-%d')"
+            for i in 1 2 3 4 5; do
+              if git push; then
+                exit 0
+              fi
+              echo "push rejected (attempt $i/5). rebasing and retrying..."
+              sleep $((i * 2))
+              git pull --rebase origin main
+            done
+            echo "push failed after 5 retries"
+            exit 1
+          fi
 
       - name: Create issue with results
         env:

--- a/.github/workflows/quote-rt.yml
+++ b/.github/workflows/quote-rt.yml
@@ -54,5 +54,14 @@ jobs:
           if [ -f history/quoted.jsonl ] && [ -n "$(git status history/quoted.jsonl --porcelain 2>/dev/null)" ]; then
             git add history/quoted.jsonl
             git commit -m "update quoted history $(TZ=Asia/Tokyo date '+%Y-%m-%d')"
-            git push
+            for i in 1 2 3 4 5; do
+              if git push; then
+                exit 0
+              fi
+              echo "push rejected (attempt $i/5). rebasing and retrying..."
+              sleep $((i * 2))
+              git pull --rebase origin main
+            done
+            echo "push failed after 5 retries"
+            exit 1
           fi


### PR DESCRIPTION
## Summary

複数ワークフローが並行して main に push する設計のため、checkout 時点と push 時点で HEAD がずれて
`failed to push some refs (fetch first)` で workflow が真っ赤に落ちる事象が発生していました。

実害として、**04-30 00:30 JST の日次ツイート生成が push 競合で失敗** → `tweets.json` が 04-29 のまま → 04-30 の投稿が**昨日と同じ内容を再投稿している**状態です（4-29 と同じ 5 スロット分）。

## 修正内容

3つの commit ステップ（`generate-tweets.yml` / `auto-like.yml` / `quote-rt.yml`）に push リトライループを追加:

```bash
for i in 1 2 3 4 5; do
  if git push; then exit 0; fi
  echo "push rejected (attempt $i/5). rebasing and retrying..."
  sleep $((i * 2))
  git pull --rebase origin main
done
```

書き込み対象ファイルは workflow ごとに分離されているため（`tweets.json` / `history/liked.jsonl` / `history/quoted.jsonl` で重複なし）、`pull --rebase` がコンテンツ衝突を起こさず常にクリーンに通る設計です。

## マージ後にやること

- **手動で `generate-tweets` workflow_dispatch を叩いて `tweets.json` を10スロット分で再生成**
  → 残り枠（19:30 / 20:30 / 22:30 など今日まだ投稿していない時間帯）から新コンテンツが流れます
  → 待てるなら明日 00:30 JST の自動再生成でも復旧します（push retry が効くため）

## Test plan

- [ ] マージ後、`generate-tweets` を `workflow_dispatch` で手動実行 → tweets.json が10スロットで commit & push 成功
- [ ] 同時間帯に auto-like の commit が走っても、両方とも push が通ること（rebase で吸収）
- [ ] `tweets.json` のスロット数が 5 → 10 に更新されることを Issue/コミット履歴で確認

https://claude.ai/code/session_01C846X3FXQERBfjJ6jqFJ2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01C846X3FXQERBfjJ6jqFJ2Y)_