### PR TITLE
Anthropic rate limit (30K tokens/分) 対策: retry + sleep

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -133,18 +133,44 @@ def save_history(category: str, text: str):
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
-def generate(prompt: str, max_tokens: int = 1500) -> str:
+def claude_call_with_retry(
+    prompt: str,
+    system: str = SYSTEM_PROMPT,
+    max_tokens: int = 1500,
+    max_retries: int = 5,
+) -> str:
+    """Anthropic API 呼び出しを 429 RateLimitError に対するバックオフ付きで実行。
+
+    レート制限（30K input tokens/分）に当たった時に指数バックオフで再試行。
+    他の HTTP エラー（401/500等）は再試行せずに即raise。
+    """
+    import time
     client = get_client()
-    message = client.messages.create(
-        model=MODEL,
-        max_tokens=max_tokens,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    for block in message.content:
-        if block.type == "text":
-            return block.text
-    return ""
+    last_err = None
+    for attempt in range(max_retries):
+        try:
+            message = client.messages.create(
+                model=MODEL,
+                max_tokens=max_tokens,
+                system=system,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            for block in message.content:
+                if block.type == "text":
+                    return block.text
+            return ""
+        except anthropic.RateLimitError as e:
+            last_err = e
+            wait = 30 * (attempt + 1)  # 30, 60, 90, 120, 150秒
+            print(f"  ⏸  Anthropic rate limit hit (attempt {attempt+1}/{max_retries}), waiting {wait}s...")
+            time.sleep(wait)
+    # 全リトライ失敗
+    raise RuntimeError(f"Anthropic rate limit persistent after {max_retries} retries: {last_err}")
+
+
+def generate(prompt: str, max_tokens: int = 1500) -> str:
+    """generate.py 内部用の薄いラッパ（後方互換）"""
+    return claude_call_with_retry(prompt, system=SYSTEM_PROMPT, max_tokens=max_tokens)
 
 
 def detect_format(line: str) -> str:
@@ -317,6 +343,7 @@ def cmd_daily(output_json: str | None = None):
 
     tweets = []
 
+    import time
     for i, ((slot, slot_label), entry) in enumerate(zip(DAILY_SLOTS, entries)):
         theme = entry["theme"]
         fmt = entry["format"]
@@ -325,6 +352,12 @@ def cmd_daily(output_json: str | None = None):
         print(f"\n{'='*60}")
         print(f"【{slot_label}】[{label}] {theme}")
         print('='*60 + "\n")
+
+        # 連続生成での Anthropic rate limit (30K input tokens/分) を回避するため、
+        # 各生成の間に短い sleep を挟む。13スロット × 平均3K input ≈ 40K tokens/min
+        # を回避できる。
+        if i > 0:
+            time.sleep(6)
 
         raw = generate_ranking(theme, fmt)
         print(raw)

--- a/generator/pr_post.py
+++ b/generator/pr_post.py
@@ -121,19 +121,15 @@ def save(fmt: str, arc: str, summary: str, posted_ids: list[str]):
 
 
 def generate(fmt: str, arc: str) -> str:
+    from generate import claude_call_with_retry  # rate-limit retry 内蔵
+
     history = load_recent_pr(arc=arc)
     prompt = PROMPTS[(fmt, arc)].format(history=history)
-    client = get_claude()
-    msg = client.messages.create(
-        model=MODEL,
-        max_tokens=2500,
+    return claude_call_with_retry(
+        prompt=prompt,
         system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    for block in msg.content:
-        if block.type == "text":
-            return block.text.strip()
-    return ""
+        max_tokens=2500,
+    ).strip()
 
 
 def parse_thread(raw: str) -> list[str]:


### PR DESCRIPTION
ユーザー報告: pr_post.py 実行時に
  anthropic.RateLimitError: 429 ... 30,000 input tokens per minute
で失敗。

原因:
- daily 生成で13スロット連続呼び出し（PR追加で純増）→ 1分内に 3K tokens × 13 ≈ 40K tokens を消費して上限超過
- pr_post.py 単発でも他ワークフロー（auto-reply等）と被ると上限超過

修正:
1) generate.py に claude_call_with_retry() を追加
   - anthropic.RateLimitError を捕捉して指数バックオフ
   - 30/60/90/120/150秒で最大5回リトライ
   - 既存 generate() は薄いラッパとして互換維持

2) cmd_daily で各生成の間に time.sleep(6) を挟む
   - 13スロット × 6秒間隔 = 78秒に分散
   - 1分あたりの token 消費を 30K 以内に収める

3) pr_post.py が claude_call_with_retry() を使うよう修正
   - 同じ retry/backoff 機構が pr_post 単発呼び出しにも効く

これで:
- daily: 13スロット間に sleep → そもそも上限に当たりにくい
- 当たっても 30s〜150s のバックオフで自動回復
- 他スクリプト（experience/friday_review/mbti_quote_rt 等）は別途 個別対応が必要だが、まず影響大きい daily と pr を救う