### PR TITLE
全機能を一時停止（schedule 撤去 + 全 job if: false）

### DIFF
--- a/.github/workflows/auto-like.yml
+++ b/.github/workflows/auto-like.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   like:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/auto-reply.yml
+++ b/.github/workflows/auto-reply.yml
@@ -1,9 +1,9 @@
 name: バズMBTIへのリプ（1日1回・21:00 JST）
 
 on:
-  schedule:
-    # 21:00 JST = 12:00 UTC（プライムタイムに1本だけ）
-    - cron: '0 12 * * *'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 21:00 JST = 12:00 UTC（プライムタイムに1本だけ）
+  #     - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/auto-reply.yml
+++ b/.github/workflows/auto-reply.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   reply:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/experience.yml
+++ b/.github/workflows/experience.yml
@@ -28,6 +28,7 @@ permissions:
 
 jobs:
   experience:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/experience.yml
+++ b/.github/workflows/experience.yml
@@ -1,9 +1,9 @@
 name: 体験談スレッド（隔日・奇数日 22:00 JST）
 
 on:
-  schedule:
-    # 22:00 JST = 13:00 UTC、毎日トリガーするが奇数日のみ実行（experience.py 内で判定）
-    - cron: '0 13 * * *'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 22:00 JST = 13:00 UTC、毎日トリガーするが奇数日のみ実行（experience.py 内で判定）
+  #     - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/friday-review.yml
+++ b/.github/workflows/friday-review.yml
@@ -1,9 +1,9 @@
 name: 金曜のINTJ反省会（毎週金 22:00 JST）
 
 on:
-  schedule:
-    # 金曜 22:00 JST = 13:00 UTC
-    - cron: '0 13 * * 5'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 金曜 22:00 JST = 13:00 UTC
+  #     - cron: '0 13 * * 5'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/friday-review.yml
+++ b/.github/workflows/friday-review.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   review:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-tweets.yml
+++ b/.github/workflows/generate-tweets.yml
@@ -1,21 +1,21 @@
 name: ツイート生成・投稿
 
 on:
-  schedule:
-    - cron: '30 15 * * *'  # 00:30 JST - 生成
-    - cron: '0 17 * * *'   # 02:00 JST - 投稿（aruaru 深夜）
-    - cron: '0 2 * * *'    # 11:00 JST - 投稿（aruaru）
-    - cron: '15 3 * * *'   # 12:15 JST - 投稿
-    - cron: '0 5 * * *'    # 14:00 JST - 投稿（aruaru）
-    - cron: '0 6 * * *'    # 15:00 JST - 投稿
-    - cron: '0 8 * * *'    # 17:00 JST - 投稿（aruaru）
-    - cron: '30 9 * * *'   # 18:30 JST - 投稿
-    - cron: '30 10 * * *'  # 19:30 JST - 投稿
-    - cron: '30 11 * * *'  # 20:30 JST - 投稿
-    - cron: '30 12 * * *'  # 21:30 JST - 投稿
-    - cron: '30 13 * * *'  # 22:30 JST - 投稿
-    - cron: '0 14 * * *'   # 23:00 JST - 投稿
-    - cron: '30 14 * * *'  # 23:30 JST - 投稿（mumble）
+  # [DISABLED 2026-05-30]   schedule:
+  #     - cron: '30 15 * * *'  # 00:30 JST - 生成
+  #     - cron: '0 17 * * *'   # 02:00 JST - 投稿（aruaru 深夜）
+  #     - cron: '0 2 * * *'    # 11:00 JST - 投稿（aruaru）
+  #     - cron: '15 3 * * *'   # 12:15 JST - 投稿
+  #     - cron: '0 5 * * *'    # 14:00 JST - 投稿（aruaru）
+  #     - cron: '0 6 * * *'    # 15:00 JST - 投稿
+  #     - cron: '0 8 * * *'    # 17:00 JST - 投稿（aruaru）
+  #     - cron: '30 9 * * *'   # 18:30 JST - 投稿
+  #     - cron: '30 10 * * *'  # 19:30 JST - 投稿
+  #     - cron: '30 11 * * *'  # 20:30 JST - 投稿
+  #     - cron: '30 12 * * *'  # 21:30 JST - 投稿
+  #     - cron: '30 13 * * *'  # 22:30 JST - 投稿
+  #     - cron: '0 14 * * *'   # 23:00 JST - 投稿
+  #     - cron: '30 14 * * *'  # 23:30 JST - 投稿（mumble）
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/generate-tweets.yml
+++ b/.github/workflows/generate-tweets.yml
@@ -24,7 +24,8 @@ permissions:
 
 jobs:
   generate:
-    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '30 15 * * *'
+    # [DISABLED 2026-05-30] 全機能一時停止中（元: workflow_dispatch or 30 15 schedule）
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,20 +85,8 @@ jobs:
           )"
 
   post:
-    if: |
-      github.event.schedule == '0 17 * * *'  ||
-      github.event.schedule == '0 2 * * *'   ||
-      github.event.schedule == '15 3 * * *'  ||
-      github.event.schedule == '0 5 * * *'   ||
-      github.event.schedule == '0 6 * * *'   ||
-      github.event.schedule == '0 8 * * *'   ||
-      github.event.schedule == '30 9 * * *'  ||
-      github.event.schedule == '30 10 * * *' ||
-      github.event.schedule == '30 11 * * *' ||
-      github.event.schedule == '30 12 * * *' ||
-      github.event.schedule == '30 13 * * *' ||
-      github.event.schedule == '0 14 * * *'  ||
-      github.event.schedule == '30 14 * * *'
+    # [DISABLED 2026-05-30] 全機能一時停止中（元: 13個の cron schedule のいずれかにマッチ）
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mbti-quote-rt.yml
+++ b/.github/workflows/mbti-quote-rt.yml
@@ -1,9 +1,9 @@
 name: MBTI/INTJ 引用RT（火・金 21:00 JST）
 
 on:
-  schedule:
-    # 火曜・金曜 21:00 JST = 12:00 UTC
-    - cron: '0 12 * * 2,5'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 火曜・金曜 21:00 JST = 12:00 UTC
+  #     - cron: '0 12 * * 2,5'
   workflow_dispatch:
     inputs:
       query:

--- a/.github/workflows/mbti-quote-rt.yml
+++ b/.github/workflows/mbti-quote-rt.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   quote-rt:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   monthly:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -1,9 +1,9 @@
 name: 月初のマチアプ収支報告（毎月1日 21:00 JST）
 
 on:
-  schedule:
-    # 毎月1日 21:00 JST = 12:00 UTC
-    - cron: '0 12 1 * *'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 毎月1日 21:00 JST = 12:00 UTC
+  #     - cron: '0 12 1 * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/poll.yml
+++ b/.github/workflows/poll.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   poll:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-post.yml
+++ b/.github/workflows/pr-post.yml
@@ -7,9 +7,9 @@ name: "アフィリエイトPR（バチェラーデート、火・木・土 21:0
 # 週3回 × auto 切替 = 各アーク週1.5回程度
 
 on:
-  schedule:
-    # 火・木・土 21:00 JST = 12:00 UTC
-    - cron: '0 12 * * 2,4,6'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 火・木・土 21:00 JST = 12:00 UTC
+  #     - cron: '0 12 * * 2,4,6'
   workflow_dispatch:
     inputs:
       format:

--- a/.github/workflows/pr-post.yml
+++ b/.github/workflows/pr-post.yml
@@ -43,6 +43,7 @@ permissions:
 
 jobs:
   pr:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quote-rt.yml
+++ b/.github/workflows/quote-rt.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   quote-rt:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-post.yml
+++ b/.github/workflows/test-post.yml
@@ -27,6 +27,7 @@ permissions:
 
 jobs:
   test:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/trend-hijack.yml
+++ b/.github/workflows/trend-hijack.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   hijack:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/trend-hijack.yml
+++ b/.github/workflows/trend-hijack.yml
@@ -1,9 +1,9 @@
 name: トレンドハイジャック（8時間ごと）
 
 on:
-  schedule:
-    # 8時間ごと: 09:00 / 17:00 / 01:00 JST = 00 / 08 / 16 UTC
-    - cron: '0 0,8,16 * * *'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 8時間ごと: 09:00 / 17:00 / 01:00 JST = 00 / 08 / 16 UTC
+  #     - cron: '0 0,8,16 * * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/viral-research.yml
+++ b/.github/workflows/viral-research.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   research:
+    if: false  # [DISABLED 2026-05-30] 全機能一時停止中
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/viral-research.yml
+++ b/.github/workflows/viral-research.yml
@@ -1,9 +1,9 @@
 name: バズツイート研究（週次・MBTI/INTJ）
 
 on:
-  schedule:
-    # 日曜 12:00 JST = 03:00 UTC
-    - cron: '0 3 * * 0'
+  # [DISABLED 2026-05-30]   schedule:
+  #     # 日曜 12:00 JST = 03:00 UTC
+  #     - cron: '0 3 * * 0'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## なぜ
ユーザーから「すべての機能を一時停止してほしい」依頼。
API 消費・自動投稿を完全に止めるため。

## 変更
2 段構えで全ジョブを停止:

1. **`schedule:` ブロックを全 workflow でコメントアウト** (commit `0366f1f`)
   - cron 自動起動を停止
2. **全 14 ジョブに `if: false` を追加** (commit `8fd1b8f`)
   - `workflow_dispatch`（手動）でも何も実行されないようにする

## 対象ジョブ (14個)
| Workflow | Job |
|---|---|
| auto-like | like |
| auto-reply | reply |
| experience | experience |
| friday-review | review |
| generate-tweets | generate, post |
| mbti-quote-rt | quote-rt |
| monthly-report | monthly |
| poll | poll |
| pr-post | pr |
| quote-rt | quote-rt |
| test-post | test |
| trend-hijack | hijack |
| viral-research | research |

## 再開方法
このマージコミットを revert すれば1コマンドで全機能復元。
`generate-tweets.yml` の元の `if:` 条件はコメントで保存済み（参照用）。

## Test plan
- [x] 全 13 workflow yml が `python -m yaml.safe_load` でパース可能
- [x] `pyyaml` で全 14 ジョブの `if` が `False` であることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01C846X3FXQERBfjJ6jqFJ2Y)_